### PR TITLE
Added error handling for loading config files from installed packages

### DIFF
--- a/packages/fractor/src/DependencyInjection/ContainerContainerBuilder.php
+++ b/packages/fractor/src/DependencyInjection/ContainerContainerBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace a9f\Fractor\DependencyInjection;
 
+use a9f\Fractor\Exception\ShouldNotHappenException;
 use a9f\FractorExtensionInstaller\Generated\InstalledPackages;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
@@ -60,7 +61,13 @@ class ContainerContainerBuilder
         }
 
         foreach (InstalledPackages::PACKAGES as $package) {
-            $collectedConfigFiles[] = $package['path'] . '/config/application.php';
+            $configPath = $package['path'] . '/config/application.php';
+
+            if (! is_readable($configPath)) {
+                throw new ShouldNotHappenException(sprintf('Config file "%s" is not readable or does not exist.', $configPath));
+            }
+
+            $collectedConfigFiles[] = $configPath;
         }
 
         return $collectedConfigFiles;

--- a/packages/fractor/src/DependencyInjection/ContainerContainerBuilder.php
+++ b/packages/fractor/src/DependencyInjection/ContainerContainerBuilder.php
@@ -64,7 +64,10 @@ class ContainerContainerBuilder
             $configPath = $package['path'] . '/config/application.php';
 
             if (! is_readable($configPath)) {
-                throw new ShouldNotHappenException(sprintf('Config file "%s" is not readable or does not exist.', $configPath));
+                throw new ShouldNotHappenException(sprintf(
+                    'Config file "%s" is not readable or does not exist.',
+                    $configPath
+                ));
             }
 
             $collectedConfigFiles[] = $configPath;


### PR DESCRIPTION
In cases where additional packages are installed but the paths to their config files cannot be loaded, fractor silently skipped them. This checks if the generated paths to the config files are readable, and throws an exception if they are not.