### PR TITLE
[BUGFIX] Try composer autoload of tool installation folder first

### DIFF
--- a/packages/fractor/bin/fractor.php
+++ b/packages/fractor/bin/fractor.php
@@ -9,9 +9,11 @@ use Symfony\Component\Console\Input\ArgvInput;
 
 $autoloadFile = (static function (): ?string {
     $candidates = [
-        getcwd() . '/vendor/autoload.php',
+        // first try the vendor folder, where fractor is installed to
         __DIR__ . '/../../../autoload.php',
         __DIR__ . '/../vendor/autoload.php',
+        // fallback to the project's vendor folder
+        getcwd() . '/vendor/autoload.php',
     ];
     foreach ($candidates as $candidate) {
         if (file_exists($candidate)) {


### PR DESCRIPTION
"fractor" as a tool may/should not be installed as a project dependency, but live separately.
Hence, the authoritative composer autoload is the
one where the tool has been installed to.

For legacy reasons the project's autoload information is kept as a fallback.

Resolves: #264