### PR TITLE
[FEATURE] Make allowed file extensions configurable for all file processors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/finder": "^5.4 || ^6.4 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
         "symplify/rule-doc-generator-contracts": "^11.2",
-        "tivie/htaccess-parser": "^0.3.0",
+        "tivie/htaccess-parser": "^0.4.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/packages/fractor-fluid/config/application.php
+++ b/packages/fractor-fluid/config/application.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use a9f\FractorFluid\Contract\FluidFractorRule;
 use a9f\FractorFluid\FluidFileProcessor;
+use a9f\FractorFluid\ValueObject\FluidFormatConfiguration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void {
@@ -16,8 +18,12 @@ return static function (ContainerConfigurator $containerConfigurator, ContainerB
 
     $services->load('a9f\\FractorFluid\\', __DIR__ . '/../src/');
 
+    $services->set('fractor.fluid_processor.format_configuration', FluidFormatConfiguration::class)
+        ->factory([null, 'createFromParameterBag']);
+
     $services->set(FluidFileProcessor::class)
-        ->arg('$rules', tagged_iterator('fractor.fluid_rule'));
+        ->arg('$rules', tagged_iterator('fractor.fluid_rule'))
+        ->arg('$fluidFormatConfiguration', service('fractor.fluid_processor.format_configuration'));
 
     $containerBuilder->registerForAutoconfiguration(FluidFractorRule::class)->addTag('fractor.fluid_rule');
 };

--- a/packages/fractor-fluid/src/Configuration/FluidProcessorOption.php
+++ b/packages/fractor-fluid/src/Configuration/FluidProcessorOption.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorFluid\Configuration;
+
+final class FluidProcessorOption
+{
+    public const ALLOWED_FILE_EXTENSIONS = 'fluid-processor-allowed-file-extensions';
+}

--- a/packages/fractor-fluid/src/FluidFileProcessor.php
+++ b/packages/fractor-fluid/src/FluidFileProcessor.php
@@ -9,6 +9,7 @@ use a9f\Fractor\Application\ValueObject\AppliedRule;
 use a9f\Fractor\Application\ValueObject\File;
 use a9f\Fractor\Caching\Detector\ChangedFilesDetector;
 use a9f\FractorFluid\Contract\FluidFractorRule;
+use a9f\FractorFluid\ValueObject\FluidFormatConfiguration;
 
 /**
  * @implements FileProcessor<FluidFractorRule>
@@ -20,7 +21,8 @@ final readonly class FluidFileProcessor implements FileProcessor
      */
     public function __construct(
         private iterable $rules,
-        private ChangedFilesDetector $changedFilesDetector
+        private ChangedFilesDetector $changedFilesDetector,
+        private FluidFormatConfiguration $fluidFormatConfiguration
     ) {
     }
 
@@ -43,9 +45,12 @@ final readonly class FluidFileProcessor implements FileProcessor
         }
     }
 
+    /**
+     * @return list<non-empty-string>
+     */
     public function allowedFileExtensions(): array
     {
-        return ['html', 'xml', 'txt'];
+        return array_values($this->fluidFormatConfiguration->allowedFileExtensions);
     }
 
     public function getAllRules(): iterable

--- a/packages/fractor-fluid/src/ValueObject/FluidFormatConfiguration.php
+++ b/packages/fractor-fluid/src/ValueObject/FluidFormatConfiguration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorFluid\ValueObject;
+
+use a9f\FractorFluid\Configuration\FluidProcessorOption;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final readonly class FluidFormatConfiguration
+{
+    /**
+     * @param array<non-empty-string> $allowedFileExtensions
+     */
+    public function __construct(
+        public array $allowedFileExtensions
+    ) {
+    }
+
+    public static function createFromParameterBag(ParameterBagInterface $parameterBag): self
+    {
+        $allowedFileExtensions = $parameterBag->has(FluidProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            ? $parameterBag->get(FluidProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            : ['html', 'xml', 'txt'];
+        $allowedFileExtensions = is_array($allowedFileExtensions) ? $allowedFileExtensions : ['html', 'xml', 'txt'];
+
+        return new self($allowedFileExtensions);
+    }
+}

--- a/packages/fractor-typoscript/src/Configuration/TypoScriptProcessorOption.php
+++ b/packages/fractor-typoscript/src/Configuration/TypoScriptProcessorOption.php
@@ -17,4 +17,6 @@ final class TypoScriptProcessorOption
     public const INDENT_CONDITIONS = 'typoscript-processor-indent-conditions';
 
     public const CONDITION_TERMINATION = 'typoscript-processor-condition-termination';
+
+    public const ALLOWED_FILE_EXTENSIONS = 'typoscript-processor-allowed-file-extensions';
 }

--- a/packages/fractor-typoscript/src/TypoScriptFileProcessor.php
+++ b/packages/fractor-typoscript/src/TypoScriptFileProcessor.php
@@ -39,7 +39,7 @@ final readonly class TypoScriptFileProcessor implements FileProcessor
 
     public function canHandle(File $file): bool
     {
-        return in_array($file->getFileExtension(), $this->allowedFileExtensions());
+        return in_array($file->getFileExtension(), $this->allowedFileExtensions(), true);
     }
 
     public function handle(File $file, iterable $appliedRules): void
@@ -75,10 +75,12 @@ final readonly class TypoScriptFileProcessor implements FileProcessor
         }
     }
 
+    /**
+     * @return list<non-empty-string>
+     */
     public function allowedFileExtensions(): array
     {
-        // TODO this should be configurable
-        return ['typoscript', 'tsconfig', 'ts'];
+        return array_values($this->typoScriptPrettyPrinterFormatConfiguration->allowedFileExtensions);
     }
 
     public function getAllRules(): iterable

--- a/packages/fractor-typoscript/src/ValueObject/TypoScriptPrettyPrinterFormatConfiguration.php
+++ b/packages/fractor-typoscript/src/ValueObject/TypoScriptPrettyPrinterFormatConfiguration.php
@@ -10,13 +10,17 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 final readonly class TypoScriptPrettyPrinterFormatConfiguration
 {
+    /**
+     * @param array<non-empty-string> $allowedFileExtensions
+     */
     public function __construct(
         public int $size,
         public string $style,
         public bool $addClosingGlobal,
         public bool $includeEmptyLineBreaks,
         public bool $indentConditions,
-        public PrettyPrinterConditionTermination $conditionTermination
+        public PrettyPrinterConditionTermination $conditionTermination,
+        public array $allowedFileExtensions
     ) {
     }
 
@@ -48,13 +52,23 @@ final readonly class TypoScriptPrettyPrinterFormatConfiguration
             ? $parameterBag->get(TypoScriptProcessorOption::CONDITION_TERMINATION)
             : PrettyPrinterConditionTermination::Keep;
 
+        $allowedFileExtensions = $parameterBag->has(TypoScriptProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            ? $parameterBag->get(TypoScriptProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            : ['typoscript', 'tsconfig', 'ts'];
+        $allowedFileExtensions = is_array($allowedFileExtensions) ? $allowedFileExtensions : [
+            'typoscript',
+            'tsconfig',
+            'ts',
+        ];
+
         return new self(
             $size,
             $style,
             $addClosingGlobal,
             $includeEmptyLineBreaks,
             $indentConditions,
-            $conditionTermination
+            $conditionTermination,
+            $allowedFileExtensions
         );
     }
 }

--- a/packages/fractor-typoscript/tests/TypoScriptStatementsIterator/Fixture/StatementCollectingVisitor.php
+++ b/packages/fractor-typoscript/tests/TypoScriptStatementsIterator/Fixture/StatementCollectingVisitor.php
@@ -27,7 +27,7 @@ final class StatementCollectingVisitor implements TypoScriptNodeVisitor
         $this->calls[] = sprintf('%s:beforeTraversal:%s', $this->visitorName, count($statements));
     }
 
-    public function enterNode(Statement $node): Statement|int
+    public function enterNode(Statement $node): Statement
     {
         $this->calls[] = sprintf('%s:enterNode:%s:l-%d', $this->visitorName, $node::class, $node->sourceLine);
         return $node;

--- a/packages/fractor-xml/config/application.php
+++ b/packages/fractor-xml/config/application.php
@@ -7,6 +7,7 @@ use a9f\FractorXml\Contract\Formatter;
 use a9f\FractorXml\Contract\XmlFractor;
 use a9f\FractorXml\IndentFactory;
 use a9f\FractorXml\PrettyXmlFormatter;
+use a9f\FractorXml\ValueObject\XmlFormatConfiguration;
 use a9f\FractorXml\XmlFileProcessor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -24,9 +25,13 @@ return static function (ContainerConfigurator $containerConfigurator, ContainerB
     $services->set('fractor.xml_processor.indent', Indent::class)
         ->factory([service(IndentFactory::class), 'create']);
 
+    $services->set('fractor.xml_processor.format_configuration', XmlFormatConfiguration::class)
+        ->factory([null, 'createFromParameterBag']);
+
     $services->set(XmlFileProcessor::class)
         ->arg('$indent', service('fractor.xml_processor.indent'))
-        ->arg('$rules', tagged_iterator('fractor.xml_rule'));
+        ->arg('$rules', tagged_iterator('fractor.xml_rule'))
+        ->arg('$xmlFormatConfiguration', service('fractor.xml_processor.format_configuration'));
 
     $services->set(\PrettyXml\Formatter::class);
     $services->alias(Formatter::class, PrettyXmlFormatter::class);

--- a/packages/fractor-xml/src/Configuration/XmlProcessorOption.php
+++ b/packages/fractor-xml/src/Configuration/XmlProcessorOption.php
@@ -9,4 +9,6 @@ final class XmlProcessorOption
     public const INDENT_SIZE = 'xml-processor-indent-size';
 
     public const INDENT_CHARACTER = 'xml-processor-indent-character';
+
+    public const ALLOWED_FILE_EXTENSIONS = 'xml-processor-allowed-file-extensions';
 }

--- a/packages/fractor-xml/src/ValueObject/XmlFormatConfiguration.php
+++ b/packages/fractor-xml/src/ValueObject/XmlFormatConfiguration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorXml\ValueObject;
+
+use a9f\FractorXml\Configuration\XmlProcessorOption;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final readonly class XmlFormatConfiguration
+{
+    /**
+     * @param array<non-empty-string> $allowedFileExtensions
+     */
+    public function __construct(
+        public array $allowedFileExtensions
+    ) {
+    }
+
+    public static function createFromParameterBag(ParameterBagInterface $parameterBag): self
+    {
+        $allowedFileExtensions = $parameterBag->has(XmlProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            ? $parameterBag->get(XmlProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            : ['xml'];
+        $allowedFileExtensions = is_array($allowedFileExtensions) ? $allowedFileExtensions : ['xml'];
+
+        return new self($allowedFileExtensions);
+    }
+}

--- a/packages/fractor-xml/src/XmlFileProcessor.php
+++ b/packages/fractor-xml/src/XmlFileProcessor.php
@@ -12,6 +12,7 @@ use a9f\Fractor\ValueObject\Indent;
 use a9f\FractorXml\Contract\DomNodeVisitor;
 use a9f\FractorXml\Contract\Formatter;
 use a9f\FractorXml\Contract\XmlFractor;
+use a9f\FractorXml\ValueObject\XmlFormatConfiguration;
 use a9f\FractorXml\ValueObjectFactory\DomDocumentFactory;
 
 /**
@@ -27,13 +28,14 @@ final readonly class XmlFileProcessor implements FileProcessor
         private Formatter $formatter,
         private iterable $rules,
         private Indent $indent,
-        private ChangedFilesDetector $changedFilesDetector
+        private ChangedFilesDetector $changedFilesDetector,
+        private XmlFormatConfiguration $xmlFormatConfiguration
     ) {
     }
 
     public function canHandle(File $file): bool
     {
-        return $file->getFileExtension() === 'xml';
+        return in_array($file->getFileExtension(), $this->allowedFileExtensions(), true);
     }
 
     /**
@@ -72,9 +74,12 @@ final readonly class XmlFileProcessor implements FileProcessor
         }
     }
 
+    /**
+     * @return list<non-empty-string>
+     */
     public function allowedFileExtensions(): array
     {
-        return ['xml'];
+        return array_values($this->xmlFormatConfiguration->allowedFileExtensions);
     }
 
     public function getAllRules(): iterable

--- a/packages/fractor-yaml/config/application.php
+++ b/packages/fractor-yaml/config/application.php
@@ -7,9 +7,11 @@ use a9f\FractorYaml\Contract\YamlFractorRule;
 use a9f\FractorYaml\Contract\YamlParser;
 use a9f\FractorYaml\SymfonyYamlDumper;
 use a9f\FractorYaml\SymfonyYamlParser;
+use a9f\FractorYaml\ValueObject\YamlFormatConfiguration;
 use a9f\FractorYaml\YamlFileProcessor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void {
@@ -23,8 +25,12 @@ return static function (ContainerConfigurator $containerConfigurator, ContainerB
     $services->alias(YamlParser::class, SymfonyYamlParser::class);
     $services->alias(YamlDumper::class, SymfonyYamlDumper::class);
 
+    $services->set('fractor.yaml_processor.format_configuration', YamlFormatConfiguration::class)
+        ->factory([null, 'createFromParameterBag']);
+
     $services->set(YamlFileProcessor::class)
-        ->arg('$rules', tagged_iterator('fractor.yaml_rule'));
+        ->arg('$rules', tagged_iterator('fractor.yaml_rule'))
+        ->arg('$yamlFormatConfiguration', service('fractor.yaml_processor.format_configuration'));
 
     $containerBuilder->registerForAutoconfiguration(YamlFractorRule::class)->addTag('fractor.yaml_rule');
 };

--- a/packages/fractor-yaml/src/Configuration/YamlProcessorOption.php
+++ b/packages/fractor-yaml/src/Configuration/YamlProcessorOption.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorYaml\Configuration;
+
+final class YamlProcessorOption
+{
+    public const ALLOWED_FILE_EXTENSIONS = 'yaml-processor-allowed-file-extensions';
+}

--- a/packages/fractor-yaml/src/ValueObject/YamlFormatConfiguration.php
+++ b/packages/fractor-yaml/src/ValueObject/YamlFormatConfiguration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorYaml\ValueObject;
+
+use a9f\FractorYaml\Configuration\YamlProcessorOption;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final readonly class YamlFormatConfiguration
+{
+    /**
+     * @param array<non-empty-string> $allowedFileExtensions
+     */
+    public function __construct(
+        public array $allowedFileExtensions
+    ) {
+    }
+
+    public static function createFromParameterBag(ParameterBagInterface $parameterBag): self
+    {
+        $allowedFileExtensions = $parameterBag->has(YamlProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            ? $parameterBag->get(YamlProcessorOption::ALLOWED_FILE_EXTENSIONS)
+            : ['yaml', 'yml'];
+        $allowedFileExtensions = is_array($allowedFileExtensions) ? $allowedFileExtensions : ['yaml', 'yml'];
+
+        return new self($allowedFileExtensions);
+    }
+}

--- a/packages/fractor-yaml/src/YamlFileProcessor.php
+++ b/packages/fractor-yaml/src/YamlFileProcessor.php
@@ -12,6 +12,7 @@ use a9f\Fractor\ValueObject\Indent;
 use a9f\FractorYaml\Contract\YamlDumper;
 use a9f\FractorYaml\Contract\YamlFractorRule;
 use a9f\FractorYaml\Contract\YamlParser;
+use a9f\FractorYaml\ValueObject\YamlFormatConfiguration;
 
 /**
  * @implements FileProcessor<YamlFractorRule>
@@ -25,7 +26,8 @@ final readonly class YamlFileProcessor implements FileProcessor
         private iterable $rules,
         private YamlParser $yamlParser,
         private YamlDumper $yamlDumper,
-        private ChangedFilesDetector $changedFilesDetector
+        private ChangedFilesDetector $changedFilesDetector,
+        private YamlFormatConfiguration $yamlFormatConfiguration
     ) {
     }
 
@@ -59,9 +61,12 @@ final readonly class YamlFileProcessor implements FileProcessor
         $file->changeFileContent($this->yamlDumper->dump($newYaml, $indent));
     }
 
+    /**
+     * @return list<non-empty-string>
+     */
     public function allowedFileExtensions(): array
     {
-        return ['yaml', 'yml'];
+        return array_values($this->yamlFormatConfiguration->allowedFileExtensions);
     }
 
     public function getAllRules(): iterable


### PR DESCRIPTION
# Make allowed file extensions configurable for all file processors

## Description

This pull request addresses the issue #337 "Feature Request: Make allowed file extensions configurable". By introducing configurable allowed file extensions, users can now customize which file extensions each processor handles without modifying source code.
The previous defined, hardcoded file extensions serve as default values, but can now be customized to the user's extend.

## Changes

### Fluid Processor

- Created `FluidProcessorOption` with `ALLOWED_FILE_EXTENSIONS` constant
- Implemented `FluidFormatConfiguration` class
- Updated `FluidFileProcessor` to read from configuration
- Added to application configuration

### TypoScript Processor

- Added `ALLOWED_FILE_EXTENSIONS` constant to `TypoScriptProcessorOption`
- Updated `TypoScriptPrettyPrinterFormatConfiguration` to accept and manage allowed file extensions
- Modified `TypoScriptFileProcessor` to use strict comparison and read from configuration

### Yaml Processor

- Created `YamlProcessorOption` with `ALLOWED_FILE_EXTENSIONS` constant
- Implemented `YamlFormatConfiguration` class for managing allowed extensions
- Updated `YamlFileProcessor` to use the new configuration class
- Modified application configuration to inject the format configuration

### Xml Processor

- Added `ALLOWED_FILE_EXTENSIONS` constant to `XmlProcessorOption`
- Created `XmlFormatConfiguration` class
- Updated `XmlFileProcessor` to use configuration and strict comparison
- Integrated into application configuration

## Commits

1. `[FEATURE] Introduce FluidFormatConfiguration and update FluidFileProcessor` - Adds configuration for Fluid processor
2. `[FEATURE] Add XmlFormatConfiguration and integrate into XmlFileProcessor` - Adds configuration for Xml processor
3. `[FEATURE] Implement YamlFormatConfiguration and integrate into YamlFileProcessor` - Adds configuration for Yaml processor
4. `[FEATURE] Enhance TypoScript configuration options` - Adds configuration for TypoScript processor
5. `[CLEANUP] Apply rector rule NarrowTooWideReturnTypeRector to StatementCollectingVisitor` - Cosmetic code improvement
6. `[TASK] Bump tivie/htaccess-parser from ^0.3.0 to ^0.4.0` - Dependency update due to `composer local:contribute`

The last two commits are cosmetic changes required to maintain code quality standards.

## Verification

To verify the changes:

1. Run `composer local:contribute` to ensure all code quality checks pass
2. Test configuration by setting allowed file extensions via Fractor parameters
3. Confirm processors now respect configured extensions instead of hardcoded ones

## Example

A simplified example configuration regarding the new configuration options might look like the following:

```php
use a9f\Fractor\Configuration\FractorConfiguration;
use a9f\FractorFluid\Configuration\FluidProcessorOption;
use a9f\FractorTypoScript\Configuration\TypoScriptProcessorOption;
use a9f\FractorXml\Configuration\XmlProcessorOption;
use a9f\FractorYaml\Configuration\YamlProcessorOption;

return FractorConfiguration::configure()
    ->withOptions([
        FluidProcessorOption::ALLOWED_FILE_EXTENSIONS => ['html'],
        TypoScriptProcessorOption::ALLOWED_FILE_EXTENSIONS => ['typoscript', 'tsconfig', 'tss', 'tsc'],
        XmlProcessorOption::ALLOWED_FILE_EXTENSIONS => ['xml', 'xlf'],
        YamlProcessorOption::ALLOWED_FILE_EXTENSIONS => ['yaml', 'yml'],
    ]);
```