### PR TITLE
[FEATURE] Introduce ProcessorSkipper for conditional processor execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ return FractorConfiguration::configure()
     ]);
 ```
 
+### Skipping FileProcessors
+
+If skipping rules, files, or folders is not sufficient, you can also skip entire processors.
+
+#### Example
+
+```php
+use a9f\FractorFluid\FluidFileProcessor;
+use a9f\FractorHtaccess\HtaccessFileProcessor;
+use a9f\FractorTypoScript\TypoScriptFileProcessor;
+use a9f\FractorXml\XmlFileProcessor;
+use a9f\FractorYaml\YamlFileProcessor;
+
+return FractorConfiguration::configure()
+    ->withSkip([
+        '*/node_modules',
+        '*/vendor/*',
+        FluidFileProcessor::class,
+        HtaccessFileProcessor::class,
+        TypoScriptFileProcessor::class,
+        XmlFileProcessor::class,
+        YamlFileProcessor::class,
+    ]);
+```
+
 ### Configure code style
 
 Fractor tries to format the code as good as possible.

--- a/packages/fractor/src/Application/FractorRunner.php
+++ b/packages/fractor/src/Application/FractorRunner.php
@@ -37,6 +37,7 @@ final readonly class FractorRunner
         private FileWriter $fileWriter,
         private FileDiffFactory $fileDiffFactory,
         private RuleSkipper $ruleSkipper,
+        private ProcessorSkipper $processorSkipper,
         private ChangedFilesDetector $changedFilesDetector,
         private ConfigurationRuleFilter $configurationRuleFilter
     ) {
@@ -70,6 +71,10 @@ final readonly class FractorRunner
                 $this->symfonyStyle->progressAdvance();
             }
             foreach ($this->processors as $processor) {
+                if ($this->processorSkipper->shouldSkip($processor::class)) {
+                    continue;
+                }
+
                 if (! $processor->canHandle($file)) {
                     continue;
                 }

--- a/packages/fractor/src/Application/ProcessorSkipper.php
+++ b/packages/fractor/src/Application/ProcessorSkipper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\Fractor\Application;
+
+use a9f\Fractor\Application\Contract\FileProcessor;
+use a9f\Fractor\Application\Contract\FractorRule;
+use a9f\Fractor\Configuration\ValueObject\SkipConfiguration;
+
+final readonly class ProcessorSkipper
+{
+    public function __construct(
+        private SkipConfiguration $configuration
+    ) {
+    }
+
+    /**
+     * @param class-string<FileProcessor<FractorRule>> $processor
+     */
+    public function shouldSkip(string $processor): bool
+    {
+        $configuredSkip = $this->configuration->getSkip();
+
+        // Check if the processor class is directly in the skip array
+        return in_array($processor, $configuredSkip, true);
+    }
+}

--- a/packages/fractor/src/Configuration/AllowedFileExtensionsResolver.php
+++ b/packages/fractor/src/Configuration/AllowedFileExtensionsResolver.php
@@ -6,6 +6,7 @@ namespace a9f\Fractor\Configuration;
 
 use a9f\Fractor\Application\Contract\FileProcessor;
 use a9f\Fractor\Application\Contract\FractorRule;
+use a9f\Fractor\Application\ProcessorSkipper;
 use Webmozart\Assert\Assert;
 
 final readonly class AllowedFileExtensionsResolver
@@ -14,7 +15,8 @@ final readonly class AllowedFileExtensionsResolver
      * @param iterable<FileProcessor<FractorRule>> $processors
      */
     public function __construct(
-        private iterable $processors
+        private iterable $processors,
+        private ProcessorSkipper $processorSkipper
     ) {
         Assert::allIsInstanceOf($this->processors, FileProcessor::class);
     }
@@ -26,6 +28,10 @@ final readonly class AllowedFileExtensionsResolver
     {
         $fileExtensions = [];
         foreach ($this->processors as $processor) {
+            if ($this->processorSkipper->shouldSkip($processor::class)) {
+                continue;
+            }
+
             $fileExtensions = array_merge($processor->allowedFileExtensions(), $fileExtensions);
         }
 

--- a/packages/fractor/src/Configuration/FractorConfigurationBuilder.php
+++ b/packages/fractor/src/Configuration/FractorConfigurationBuilder.php
@@ -23,8 +23,7 @@ use Webmozart\Assert\Assert;
  * An instance of the builder can be obtained via {@see FractorConfiguration::configure()} or from an instance
  * of {@see ContainerBuilder} passed to the callable returned by fractor.php.
  *
- * @phpstan-import-type TSkipForRules from SkipConfiguration
- * @phpstan-import-type TGlobalSkip from SkipConfiguration
+ * @phpstan-import-type TSkipConfiguration from SkipConfiguration
  */
 final class FractorConfigurationBuilder
 {
@@ -39,7 +38,7 @@ final class FractorConfigurationBuilder
     private array $paths = [];
 
     /**
-     * @var TSkipForRules|TGlobalSkip
+     * @var TSkipConfiguration
      */
     private array $skip = [];
 
@@ -163,7 +162,7 @@ final class FractorConfigurationBuilder
     }
 
     /**
-     * @param TSkipForRules|TGlobalSkip $skip
+     * @param TSkipConfiguration $skip
      */
     public function withSkip(array $skip): self
     {

--- a/packages/fractor/src/Configuration/ValueObject/SkipConfiguration.php
+++ b/packages/fractor/src/Configuration/ValueObject/SkipConfiguration.php
@@ -4,26 +4,33 @@ declare(strict_types=1);
 
 namespace a9f\Fractor\Configuration\ValueObject;
 
+use a9f\Fractor\Application\Contract\FileProcessor;
 use a9f\Fractor\Application\Contract\FractorRule;
 
 /**
- * The configuration which paths to skip, optionally narrowed to single rules.
+ * The configuration which paths to skip, optionally narrowed to single rules or processors.
  *
  * @phpstan-type TSkipForRules array<class-string<FractorRule>, string|list<string>>
+ * @phpstan-type TSkipForProcessors array<class-string<FileProcessor<FractorRule>>, string|list<string>>
  * @phpstan-type TGlobalSkip array<int, string>
+ * @phpstan-type TProcessorSkip array<int, class-string<FileProcessor<FractorRule>>>
+ * @phpstan-type TSkipConfiguration TSkipForRules|TSkipForProcessors|TGlobalSkip|TProcessorSkip
  */
 final readonly class SkipConfiguration
 {
     /**
-     * @param TSkipForRules|TGlobalSkip $skip
+     * @param TSkipConfiguration $skip
      */
     public function __construct(
+        /**
+         * @phpstan-var TSkipConfiguration
+         */
         private array $skip
     ) {
     }
 
     /**
-     * @return TSkipForRules|TGlobalSkip
+     * @return TSkipConfiguration
      */
     public function getSkip(): array
     {


### PR DESCRIPTION
# Introduce ProcessorSkipper for a distinguished processor execution

## Summary

This PR adds the `ProcessorSkipper` class to enable conditional skipping of file processors based on configuration, which addresses issue #209. The feature allows more granular control over which processors are executed, improving flexibility for complex scenarios.

## Key Changes

- **ProcessorSkipper**: New class to manage processor skipping logic.
- **Integration**: `ProcessorSkipper` is now injected and used in both `FractorRunner` and `AllowedFileExtensionsResolver` to skip processors as configured.
- **Configuration**: `SkipConfiguration` and `FractorConfigurationBuilder` updated to support processor skipping alongside rule/path skipping.

## Details

- Processors can be skipped by specifying their class in the skip configuration.
- All relevant classes and type annotations have been updated to reflect the new configuration options.
- No breaking changes; existing skip logic for rules and paths remains supported.

## Example

```php
use a9f\FractorFluid\FluidFileProcessor;
use a9f\FractorHtaccess\HtaccessFileProcessor;
use a9f\FractorTypoScript\TypoScriptFileProcessor;
use a9f\FractorXml\XmlFileProcessor;
use a9f\FractorYaml\YamlFileProcessor;

return FractorConfiguration::configure()
    ->withSkip([
        '*/node_modules',
        '*/vendor/*',
        FluidFileProcessor::class,
        HtaccessFileProcessor::class,
        TypoScriptFileProcessor::class,
        XmlFileProcessor::class,
        YamlFileProcessor::class,
    ]);
```
