### PR TITLE
Migrate condition operators

### DIFF
--- a/packages/typo3-fractor/config/typo3-10.php
+++ b/packages/typo3-fractor/config/typo3-10.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use a9f\Typo3Fractor\TYPO3v10\Fluid\RemoveNoCacheHashAndUseCacheHashAttributeFluidFractor;
 use a9f\Typo3Fractor\TYPO3v10\TypoScript\MigrateLegacyTypoScriptConditionsFractor;
+use a9f\Typo3Fractor\TYPO3v10\TypoScript\MigrateTypoScriptMultipleConditionBracketsFractor;
 use a9f\Typo3Fractor\TYPO3v10\TypoScript\MigrateTypoScriptPageConditionPipeAccessFractor;
 use a9f\Typo3Fractor\TYPO3v10\TypoScript\RemoveConfigConcatenateJsAndCssFractor;
 use a9f\Typo3Fractor\TYPO3v10\TypoScript\RemoveConfigDefaultGetVarsFractor;
@@ -39,6 +40,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RemoveNoCacheHashAndUseCacheHashAttributeFluidFractor::class);
     $services->set(RemoveUseCacheHashFromTypolinkTypoScriptFractor::class);
     $services->set(MigrateLegacyTypoScriptConditionsFractor::class);
+    $services->set(MigrateTypoScriptMultipleConditionBracketsFractor::class);
     $services->set(MigrateTypoScriptPageConditionPipeAccessFractor::class);
     $services->set(RemoveConfigConcatenateJsAndCssFractor::class);
     $services->set(RemoveConfigDefaultGetVarsFractor::class);

--- a/packages/typo3-fractor/docs/typo3-fractor-rules.md
+++ b/packages/typo3-fractor/docs/typo3-fractor-rules.md
@@ -1,4 +1,4 @@
-# 68 Rules Overview
+# 69 Rules Overview
 
 ## AbstractMessageGetSeverityFluidFractor
 
@@ -739,6 +739,30 @@ Migrate TypoScript loginUser and usergroup conditions (both function-call and eq
      page = PAGE
      page.30 = TEXT
      page.30.value = User is in group 1 or 2
+ [end]
+```
+
+<br>
+
+## MigrateTypoScriptMultipleConditionBracketsFractor
+
+Merge multiple TypoScript condition bracket pairs into a single bracket with logical operators inside
+
+- class: [`a9f\Typo3Fractor\TYPO3v10\TypoScript\MigrateTypoScriptMultipleConditionBracketsFractor`](../rules/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor.php)
+
+```diff
+-[conditionA] || [conditionB]
++[conditionA || conditionB]
+     page = PAGE
+ [end]
+```
+
+<br>
+
+```diff
+-[conditionA] && [conditionB]
++[conditionA && conditionB]
+     page = PAGE
  [end]
 ```
 

--- a/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture10.typoscript.fixture
+++ b/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture10.typoscript.fixture
@@ -1,0 +1,7 @@
+[conditionA] || [conditionB]
+    page = PAGE
+[end]
+-----
+[conditionA || conditionB]
+    page = PAGE
+[end]

--- a/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture20.typoscript.fixture
+++ b/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture20.typoscript.fixture
@@ -1,0 +1,7 @@
+[conditionA] && [conditionB]
+    page = PAGE
+[end]
+-----
+[conditionA && conditionB]
+    page = PAGE
+[end]

--- a/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture30.typoscript.fixture
+++ b/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture30.typoscript.fixture
@@ -1,0 +1,7 @@
+[conditionA] || [conditionB] || [conditionC]
+    page = PAGE
+[end]
+-----
+[conditionA || conditionB || conditionC]
+    page = PAGE
+[end]

--- a/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture40.typoscript.fixture
+++ b/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/Fixtures/fixture40.typoscript.fixture
@@ -1,0 +1,7 @@
+[traverse(request?.getQueryParams(), 'tx_t3extblog_blogsystem/post') > 0] || [traverse(request?.getQueryParams(), 'tx_news_pi1/news') > 0]
+    page = PAGE
+[end]
+-----
+[traverse(request?.getQueryParams(), 'tx_t3extblog_blogsystem/post') > 0 || traverse(request?.getQueryParams(), 'tx_news_pi1/news') > 0]
+    page = PAGE
+[end]

--- a/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/MigrateTypoScriptMultipleConditionBracketsFractorTest.php
+++ b/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/MigrateTypoScriptMultipleConditionBracketsFractorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\Typo3Fractor\Tests\TYPO3v10\TypoScript\MigrateTypoScriptMultipleConditionBracketsFractor;
+
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class MigrateTypoScriptMultipleConditionBracketsFractorTest extends AbstractFractorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures', '*.typoscript.fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+}

--- a/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/config/fractor.php
+++ b/packages/typo3-fractor/rules-tests/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor/config/fractor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\FractorTypoScript\Configuration\TypoScriptProcessorOption;
+use a9f\Typo3Fractor\TYPO3v10\TypoScript\MigrateTypoScriptMultipleConditionBracketsFractor;
+use Helmich\TypoScriptParser\Parser\Printer\PrettyPrinterConditionTermination;
+use Helmich\TypoScriptParser\Parser\Printer\PrettyPrinterConfiguration;
+
+return FractorConfiguration::configure()
+    ->withOptions([
+        TypoScriptProcessorOption::INDENT_SIZE => 4,
+        TypoScriptProcessorOption::INDENT_CHARACTER => PrettyPrinterConfiguration::INDENTATION_STYLE_SPACES,
+        TypoScriptProcessorOption::ADD_CLOSING_GLOBAL => false,
+        TypoScriptProcessorOption::INCLUDE_EMPTY_LINE_BREAKS => true,
+        TypoScriptProcessorOption::INDENT_CONDITIONS => true,
+        TypoScriptProcessorOption::CONDITION_TERMINATION => PrettyPrinterConditionTermination::Keep,
+    ])
+    ->withRules([MigrateTypoScriptMultipleConditionBracketsFractor::class]);

--- a/packages/typo3-fractor/rules/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor.php
+++ b/packages/typo3-fractor/rules/TYPO3v10/TypoScript/MigrateTypoScriptMultipleConditionBracketsFractor.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\Typo3Fractor\TYPO3v10\TypoScript;
+
+use a9f\FractorTypoScript\AbstractTypoScriptFractor;
+use Helmich\TypoScriptParser\Parser\AST\ConditionalStatement;
+use Helmich\TypoScriptParser\Parser\AST\Statement;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5/Deprecation-86068-OldConditionSyntax.html
+ * @see \a9f\Typo3Fractor\Tests\TYPO3v10\TypoScript\MigrateTypoScriptMultipleConditionBracketsFractor\MigrateTypoScriptMultipleConditionBracketsFractorTest
+ */
+final class MigrateTypoScriptMultipleConditionBracketsFractor extends AbstractTypoScriptFractor
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Merge multiple TypoScript condition bracket pairs into a single bracket with logical operators inside',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+[conditionA] || [conditionB]
+    page = PAGE
+[end]
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+[conditionA || conditionB]
+    page = PAGE
+[end]
+CODE_SAMPLE
+                ),
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+[conditionA] && [conditionB]
+    page = PAGE
+[end]
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+[conditionA && conditionB]
+    page = PAGE
+[end]
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function refactor(Statement $statement): ?Statement
+    {
+        if (! $statement instanceof ConditionalStatement) {
+            return null;
+        }
+
+        $condition = $statement->condition;
+        $originalCondition = $condition;
+
+        $condition = $this->mergeMultipleBracketConditions($condition);
+
+        if ($condition === $originalCondition) {
+            return null;
+        }
+
+        $statement->condition = $condition;
+
+        return $statement;
+    }
+
+    private function mergeMultipleBracketConditions(string $condition): string
+    {
+        // Quick check: does it contain the pattern '] ||' or '] &&'?
+        if (! preg_match('/\]\s*(\|\||&&)\s*\[/', $condition)) {
+            return $condition;
+        }
+
+        $expressions = [];
+        $operators = [];
+        $remaining = trim($condition);
+
+        while ($remaining !== '') {
+            if (! preg_match('/^\[([^\]]*)\](.*)$/s', $remaining, $m)) {
+                // Unexpected format, bail out without changing anything
+                return $condition;
+            }
+
+            $expressions[] = $m[1];
+            $remaining = trim($m[2]);
+
+            if ($remaining === '') {
+                break;
+            }
+
+            if (preg_match('/^(\|\||&&)\s*(.*)$/s', $remaining, $opMatch)) {
+                $operators[] = $opMatch[1];
+                $remaining = trim($opMatch[2]);
+            } else {
+                // Unexpected token after closing bracket, bail out
+                return $condition;
+            }
+        }
+
+        if (count($expressions) < 2) {
+            return $condition;
+        }
+
+        $merged = '';
+        foreach ($expressions as $i => $expr) {
+            if ($i > 0) {
+                $merged .= ' ' . $operators[$i - 1] . ' ';
+            }
+
+            $merged .= $expr;
+        }
+
+        return '[' . $merged . ']';
+    }
+}


### PR DESCRIPTION
From this legacy syntax:

```
[conditionA] || [conditionB]
    page = PAGE
[end]
```

to the new symfony-only syntax:

```
[conditionA || conditionB]
    page = PAGE
[end]
```