### PR TITLE
[FEATURE] Add a virtual CodeFormatRule to stop silently swallowing formatting-only changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,10 @@ insert_final_newline = true
 [tabs.txt]
 indent_style = tab
 
+# Text fixtures deliberately carry trailing whitespace to exercise reformatting
+[*.txt.fixture]
+trim_trailing_whitespace = false
+
 # YAML-Files
 [{*.yml,*.yaml,*.yml.fixture,*.yaml.fixture}]
 indent_size = 2

--- a/e2e/typo3-yaml/expected-output.txt
+++ b/e2e/typo3-yaml/expected-output.txt
@@ -9,9 +9,8 @@
    -
      options:
        recipients:
--        bar@domain.com: 'Bar'
 +        foo@domain.com: Bar
-+        bar@domain.com: Bar
+         bar@domain.com: Bar
        subject: 'Kontaktanfrage von Website'
 -      recipientAddress: foo@domain.com
 -      recipientName: Bar
@@ -32,9 +31,8 @@
    -
      options:
        recipients:
--        bar@domain.com: 'Bar'
 +        foo@domain.com: Bar
-+        bar@domain.com: Bar
+         bar@domain.com: Bar
        subject: 'Kontaktanfrage von Website'
 -      recipientAddress: foo@domain.com
 -      recipientName: Bar
@@ -70,8 +68,9 @@
     ----------- end diff -----------
 
 Applied rules:
+ * CodeFormatRule
  * EmailFinisherYamlFractor
 
 
- [OK] 1 file has been changed by Fractor
+ [OK] 1 file has been changed by Fractor                                        
 

--- a/packages/fractor-composer-json/src/ComposerJsonFileProcessor.php
+++ b/packages/fractor-composer-json/src/ComposerJsonFileProcessor.php
@@ -36,23 +36,28 @@ final readonly class ComposerJsonFileProcessor implements FileProcessor
 
     public function handle(File $file, iterable $appliedRules): void
     {
-        $fileHasChanged = \false;
+        $rawContent = $file->getContent();
         $composerJson = $this->composerJsonFactory->createFromFile($file);
-        $oldComposerJson = $this->composerJsonFactory->createFromFile($file);
 
         foreach ($appliedRules as $rule) {
+            $beforeArray = $composerJson->getJsonArray();
             $rule->refactor($composerJson);
 
-            if ($oldComposerJson->getJsonArray() !== $composerJson->getJsonArray()) {
-                $file->changeFileContent($this->composerJsonPrinter->printToString($this->indent, $composerJson));
+            if ($beforeArray !== $composerJson->getJsonArray()) {
                 $file->addAppliedRule(AppliedRule::fromRule($rule));
-                $fileHasChanged = \true;
             }
         }
 
-        if (! $fileHasChanged) {
+        // Always re-print: a formatting-only change (indentation) is then
+        // attributed to CodeFormatRule by the runner rather than applied silently.
+        $newContent = rtrim($this->composerJsonPrinter->printToString($this->indent, $composerJson)) . "\n";
+
+        if ($newContent === $rawContent) {
             $this->changedFilesDetector->addCachableFile($file->getFilePath());
+            return;
         }
+
+        $file->changeFileContent($newContent);
     }
 
     public function allowedFileExtensions(): array

--- a/packages/fractor-composer-json/tests/ComposerJsonProcessResult/ComposerJsonProcessResultTest.php
+++ b/packages/fractor-composer-json/tests/ComposerJsonProcessResult/ComposerJsonProcessResultTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorComposerJson\Tests\ComposerJsonProcessResult;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use a9f\FractorComposerJson\RemovePackageComposerJsonFractor;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The composer.json processor re-prints files it touches, so a formatting-only
+ * change (indentation) must be attributed to the virtual CodeFormatRule — so a
+ * re-indentation is reported rather than applied silently — while a real
+ * transformation stays attributed to its own rule.
+ */
+final class ComposerJsonProcessResultTest extends AbstractFractorTestCase
+{
+    /**
+     * @param list<string> $expectedAppliedRules
+     */
+    #[DataProvider('provideData')]
+    public function test(string $fixture, array $expectedAppliedRules): void
+    {
+        $fractorTestResult = $this->doTestFile(__DIR__ . '/Fixtures/' . $fixture);
+
+        self::assertSame($expectedAppliedRules, $fractorTestResult->getAppliedFractorRules());
+    }
+
+    /**
+     * @return \Iterator<string, array{string, list<string>}>
+     */
+    public static function provideData(): \Iterator
+    {
+        yield 'rule change is attributed to the real rule' => [
+            'rule-change/composer.json.fixture',
+            [RemovePackageComposerJsonFractor::class],
+        ];
+        yield 'pure reformat is attributed to the virtual code-format rule' => [
+            'reformatting/composer.json.fixture',
+            [AppliedRule::CODE_FORMAT_RULE],
+        ];
+        yield 'already formatted file reports no change' => ['already-formatted/composer.json.fixture', []];
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+}

--- a/packages/fractor-composer-json/tests/ComposerJsonProcessResult/Fixtures/already-formatted/composer.json.fixture
+++ b/packages/fractor-composer-json/tests/ComposerJsonProcessResult/Fixtures/already-formatted/composer.json.fixture
@@ -1,0 +1,6 @@
+{
+    "name": "acme/demo",
+    "require": {
+        "vendor1/keep": "^2.0"
+    }
+}

--- a/packages/fractor-composer-json/tests/ComposerJsonProcessResult/Fixtures/reformatting/composer.json.fixture
+++ b/packages/fractor-composer-json/tests/ComposerJsonProcessResult/Fixtures/reformatting/composer.json.fixture
@@ -1,0 +1,13 @@
+{
+  "name": "acme/demo",
+  "require": {
+    "vendor1/keep": "^2.0"
+  }
+}
+-----
+{
+    "name": "acme/demo",
+    "require": {
+        "vendor1/keep": "^2.0"
+    }
+}

--- a/packages/fractor-composer-json/tests/ComposerJsonProcessResult/Fixtures/rule-change/composer.json.fixture
+++ b/packages/fractor-composer-json/tests/ComposerJsonProcessResult/Fixtures/rule-change/composer.json.fixture
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "vendor1/legacy": "^1.0",
+        "vendor1/keep": "^2.0"
+    }
+}
+-----
+{
+    "require": {
+        "vendor1/keep": "^2.0"
+    }
+}

--- a/packages/fractor-composer-json/tests/ComposerJsonProcessResult/config/fractor.php
+++ b/packages/fractor-composer-json/tests/ComposerJsonProcessResult/config/fractor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\FractorComposerJson\RemovePackageComposerJsonFractor;
+
+return FractorConfiguration::configure()
+    ->import(__DIR__ . '/../../../config/application.php')
+    ->withConfiguredRule(RemovePackageComposerJsonFractor::class, ['vendor1/legacy']);

--- a/packages/fractor-typoscript/tests/TypoScriptProcessResult/Fixtures/already-formatted.typoscript.fixture
+++ b/packages/fractor-typoscript/tests/TypoScriptProcessResult/Fixtures/already-formatted.typoscript.fixture
@@ -1,0 +1,3 @@
+page = PAGE
+page.10 = TEXT
+page.10.value = Hello

--- a/packages/fractor-typoscript/tests/TypoScriptProcessResult/Fixtures/reformatting.typoscript.fixture
+++ b/packages/fractor-typoscript/tests/TypoScriptProcessResult/Fixtures/reformatting.typoscript.fixture
@@ -1,0 +1,7 @@
+page = PAGE
+     page.10 = TEXT
+     page.10.value = Hello
+-----
+page = PAGE
+page.10 = TEXT
+page.10.value = Hello

--- a/packages/fractor-typoscript/tests/TypoScriptProcessResult/Fixtures/rule-change.typoscript.fixture
+++ b/packages/fractor-typoscript/tests/TypoScriptProcessResult/Fixtures/rule-change.typoscript.fixture
@@ -1,0 +1,4 @@
+page = PAGE
+config.spamProtectEmailAddresses = ascii
+-----
+page = PAGE

--- a/packages/fractor-typoscript/tests/TypoScriptProcessResult/TypoScriptProcessResultTest.php
+++ b/packages/fractor-typoscript/tests/TypoScriptProcessResult/TypoScriptProcessResultTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorTypoScript\Tests\TypoScriptProcessResult;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use a9f\FractorTypoScript\Tests\Fixtures\DummyTypoScriptFractorRule;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The TypoScript pretty-printer re-formats files it touches, so a formatting-only
+ * reformat must be attributed to the virtual CodeFormatRule (and count toward the
+ * exit code), while a real transformation stays attributed to its own rule.
+ */
+final class TypoScriptProcessResultTest extends AbstractFractorTestCase
+{
+    /**
+     * @param list<string> $expectedAppliedRules
+     */
+    #[DataProvider('provideData')]
+    public function test(string $fixture, array $expectedAppliedRules): void
+    {
+        $fractorTestResult = $this->doTestFile(__DIR__ . '/Fixtures/' . $fixture);
+
+        self::assertSame($expectedAppliedRules, $fractorTestResult->getAppliedFractorRules());
+    }
+
+    /**
+     * @return \Iterator<string, array{string, list<string>}>
+     */
+    public static function provideData(): \Iterator
+    {
+        yield 'rule change is attributed to the real rule' => [
+            'rule-change.typoscript.fixture',
+            [DummyTypoScriptFractorRule::class],
+        ];
+        yield 'pure reformat is attributed to the virtual code-format rule' => [
+            'reformatting.typoscript.fixture',
+            [AppliedRule::CODE_FORMAT_RULE],
+        ];
+        yield 'already formatted file reports no change' => ['already-formatted.typoscript.fixture', []];
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+}

--- a/packages/fractor-typoscript/tests/TypoScriptProcessResult/config/fractor.php
+++ b/packages/fractor-typoscript/tests/TypoScriptProcessResult/config/fractor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\FractorTypoScript\Configuration\TypoScriptProcessorOption;
+use a9f\FractorTypoScript\Tests\Fixtures\DummyTypoScriptFractorRule;
+use Helmich\TypoScriptParser\Parser\Printer\PrettyPrinterConditionTermination;
+use Helmich\TypoScriptParser\Parser\Printer\PrettyPrinterConfiguration;
+
+return FractorConfiguration::configure()
+    ->withOptions([
+        TypoScriptProcessorOption::INDENT_SIZE => 4,
+        TypoScriptProcessorOption::INDENT_CHARACTER => PrettyPrinterConfiguration::INDENTATION_STYLE_SPACES,
+        TypoScriptProcessorOption::ADD_CLOSING_GLOBAL => false,
+        TypoScriptProcessorOption::INCLUDE_EMPTY_LINE_BREAKS => true,
+        TypoScriptProcessorOption::INDENT_CONDITIONS => true,
+        TypoScriptProcessorOption::CONDITION_TERMINATION => PrettyPrinterConditionTermination::Keep,
+    ])
+    ->withRules([DummyTypoScriptFractorRule::class]);

--- a/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/already-formatted.xlf.fixture
+++ b/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/already-formatted.xlf.fixture
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff
+	xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file source-language="en" datatype="plaintext" original="messages">
+		<body>
+			<trans-unit id="key1" xml:space="preserve">
+				<source>Goodbye</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/reformatting.xlf.fixture
+++ b/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/reformatting.xlf.fixture
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+  <trans-unit id="key1" xml:space="preserve">
+  <source>Goodbye</source>
+  </trans-unit>
+        </body>
+  </file>
+</xliff>
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff
+	xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file source-language="en" datatype="plaintext" original="messages">
+		<body>
+			<trans-unit id="key1" xml:space="preserve">
+				<source>Goodbye</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/rule-and-formatting.xlf.fixture
+++ b/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/rule-and-formatting.xlf.fixture
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+  <trans-unit id="key1" xml:space="preserve">
+  <source>Hello</source>
+  </trans-unit>
+        </body>
+  </file>
+</xliff>
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff
+	xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file source-language="en" datatype="plaintext" original="messages">
+		<body>
+			<trans-unit id="key1" xml:space="preserve">
+				<source>Hello World</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/rule-change.xlf.fixture
+++ b/packages/fractor-xliff/tests/XliffProcessResult/Fixtures/rule-change.xlf.fixture
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff
+	xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file source-language="en" datatype="plaintext" original="messages">
+		<body>
+			<trans-unit id="key1" xml:space="preserve">
+				<source>Hello</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff
+	xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file source-language="en" datatype="plaintext" original="messages">
+		<body>
+			<trans-unit id="key1" xml:space="preserve">
+				<source>Hello World</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fractor-xliff/tests/XliffProcessResult/XliffProcessResultTest.php
+++ b/packages/fractor-xliff/tests/XliffProcessResult/XliffProcessResultTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorXliff\Tests\XliffProcessResult;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use a9f\FractorXliff\Tests\Fixtures\DummyXliffFractorRule;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * A change (rule or re-formatting) must be reported and count toward the dry-run
+ * exit code; a pure reformat is attributed to the virtual CodeFormatRule, a real
+ * rule to itself, and an unchanged file reports nothing.
+ */
+final class XliffProcessResultTest extends AbstractFractorTestCase
+{
+    /**
+     * @param list<string> $expectedAppliedRules
+     */
+    #[DataProvider('provideData')]
+    public function test(string $fixture, array $expectedAppliedRules): void
+    {
+        $fractorTestResult = $this->doTestFile(__DIR__ . '/Fixtures/' . $fixture);
+
+        self::assertSame($expectedAppliedRules, $fractorTestResult->getAppliedFractorRules());
+    }
+
+    /**
+     * @return \Iterator<string, array{string, list<string>}>
+     */
+    public static function provideData(): \Iterator
+    {
+        yield 'rule change is attributed to the real rule' => [
+            'rule-change.xlf.fixture',
+            [DummyXliffFractorRule::class],
+        ];
+        yield 'pure reformat is attributed to the virtual code-format rule' => [
+            'reformatting.xlf.fixture',
+            [AppliedRule::CODE_FORMAT_RULE],
+        ];
+        yield 'rule change and reformat are both reported' => [
+            'rule-and-formatting.xlf.fixture',
+            [AppliedRule::CODE_FORMAT_RULE, DummyXliffFractorRule::class],
+        ];
+        yield 'already formatted file reports no change' => ['already-formatted.xlf.fixture', []];
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+}

--- a/packages/fractor-xliff/tests/XliffProcessResult/config/fractor.php
+++ b/packages/fractor-xliff/tests/XliffProcessResult/config/fractor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\Fractor\ValueObject\Indent;
+use a9f\FractorXliff\Configuration\XliffProcessorOption;
+use a9f\FractorXliff\Tests\Fixtures\DummyXliffFractorRule;
+
+return FractorConfiguration::configure()
+    ->withOptions([
+        XliffProcessorOption::INDENT_CHARACTER => Indent::STYLE_TAB,
+        XliffProcessorOption::INDENT_SIZE => 1,
+    ])
+    ->withRules([DummyXliffFractorRule::class]);

--- a/packages/fractor-xml/tests/XmlProcessResult/Fixtures/already-formatted.xml.fixture
+++ b/packages/fractor-xml/tests/XmlProcessResult/Fixtures/already-formatted.xml.fixture
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+	<item key="a">value</item>
+	<item key="b">value</item>
+</root>

--- a/packages/fractor-xml/tests/XmlProcessResult/Fixtures/reformatting.xml.fixture
+++ b/packages/fractor-xml/tests/XmlProcessResult/Fixtures/reformatting.xml.fixture
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item key="a">value</item>
+  <item key="b">value</item>
+</root>
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+	<item key="a">value</item>
+	<item key="b">value</item>
+</root>

--- a/packages/fractor-xml/tests/XmlProcessResult/Fixtures/rule-and-formatting.xml.fixture
+++ b/packages/fractor-xml/tests/XmlProcessResult/Fixtures/rule-and-formatting.xml.fixture
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<T3DataStructure>
+  <sheets>
+    <sDEF>
+      <ROOT>
+        <el>
+          <settings.input>
+            <config>
+              <type>input</type>
+              <max>50</max>
+            </config>
+          </settings.input>
+        </el>
+      </ROOT>
+    </sDEF>
+  </sheets>
+</T3DataStructure>
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<T3DataStructure>
+	<sheets>
+		<sDEF>
+			<ROOT>
+				<el>
+					<settings.input>
+						<config>
+							<type>input</type>
+						</config>
+					</settings.input>
+				</el>
+			</ROOT>
+		</sDEF>
+	</sheets>
+</T3DataStructure>

--- a/packages/fractor-xml/tests/XmlProcessResult/Fixtures/rule-change.xml.fixture
+++ b/packages/fractor-xml/tests/XmlProcessResult/Fixtures/rule-change.xml.fixture
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<T3DataStructure>
+	<sheets>
+		<sDEF>
+			<ROOT>
+				<el>
+					<settings.input>
+						<config>
+							<type>input</type>
+							<max>50</max>
+						</config>
+					</settings.input>
+				</el>
+			</ROOT>
+		</sDEF>
+	</sheets>
+</T3DataStructure>
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<T3DataStructure>
+	<sheets>
+		<sDEF>
+			<ROOT>
+				<el>
+					<settings.input>
+						<config>
+							<type>input</type>
+						</config>
+					</settings.input>
+				</el>
+			</ROOT>
+		</sDEF>
+	</sheets>
+</T3DataStructure>

--- a/packages/fractor-xml/tests/XmlProcessResult/XmlProcessResultTest.php
+++ b/packages/fractor-xml/tests/XmlProcessResult/XmlProcessResultTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorXml\Tests\XmlProcessResult;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use a9f\FractorXml\Tests\Fixtures\DummyXmlFractorRule;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The XML processor re-indents files it touches, so a formatting-only reformat
+ * must be attributed to the virtual CodeFormatRule (and count toward the exit
+ * code), while a real transformation stays attributed to its own rule.
+ */
+final class XmlProcessResultTest extends AbstractFractorTestCase
+{
+    /**
+     * @param list<string> $expectedAppliedRules
+     */
+    #[DataProvider('provideData')]
+    public function test(string $fixture, array $expectedAppliedRules): void
+    {
+        $fractorTestResult = $this->doTestFile(__DIR__ . '/Fixtures/' . $fixture);
+
+        self::assertSame($expectedAppliedRules, $fractorTestResult->getAppliedFractorRules());
+    }
+
+    /**
+     * @return \Iterator<string, array{string, list<string>}>
+     */
+    public static function provideData(): \Iterator
+    {
+        yield 'rule change is attributed to the real rule' => ['rule-change.xml.fixture', [DummyXmlFractorRule::class]];
+        yield 'pure reformat is attributed to the virtual code-format rule' => [
+            'reformatting.xml.fixture',
+            [AppliedRule::CODE_FORMAT_RULE],
+        ];
+        yield 'rule change and reformat are both reported' => [
+            'rule-and-formatting.xml.fixture',
+            [AppliedRule::CODE_FORMAT_RULE, DummyXmlFractorRule::class],
+        ];
+        yield 'already formatted file reports no change' => ['already-formatted.xml.fixture', []];
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+}

--- a/packages/fractor-xml/tests/XmlProcessResult/config/fractor.php
+++ b/packages/fractor-xml/tests/XmlProcessResult/config/fractor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\Fractor\ValueObject\Indent;
+use a9f\FractorXml\Configuration\XmlProcessorOption;
+use a9f\FractorXml\Tests\Fixtures\DummyXmlFractorRule;
+
+return FractorConfiguration::configure()
+    ->withOptions([
+        XmlProcessorOption::INDENT_CHARACTER => Indent::STYLE_TAB,
+        XmlProcessorOption::INDENT_SIZE => 1,
+    ])
+    ->withRules([DummyXmlFractorRule::class]);

--- a/packages/fractor-yaml/src/YamlFileProcessor.php
+++ b/packages/fractor-yaml/src/YamlFileProcessor.php
@@ -52,13 +52,17 @@ final readonly class YamlFileProcessor implements FileProcessor
             }
         }
 
-        // Nothing has changed.
+        // Never re-dump for formatting alone: the dumper drops comments, so
+        // untouched files stay byte-exact.
         if ($newYaml === $yaml) {
             $this->changedFilesDetector->addCachableFile($file->getFilePath());
             return;
         }
 
-        $file->changeFileContent($this->yamlDumper->dump($newYaml, $indent));
+        // Re-dumped original as baseline: the diff shows only the rule's change,
+        // any extra reformatting is attributed to CodeFormatRule by the runner.
+        $file->changeOriginalContent(rtrim($this->yamlDumper->dump($yaml, $indent)) . "\n");
+        $file->changeFileContent(rtrim($this->yamlDumper->dump($newYaml, $indent)) . "\n");
     }
 
     /**

--- a/packages/fractor-yaml/tests/YamlProcessResult/Fixtures/rule-and-reformat.yaml.fixture
+++ b/packages/fractor-yaml/tests/YamlProcessResult/Fixtures/rule-and-reformat.yaml.fixture
@@ -1,0 +1,13 @@
+# this comment is lost when the file is re-dumped
+Form:
+  renderingOptions:
+    translation:
+      translationFile:
+        10: 'EXT:form/Resources/Private/Language/locallang.xlf'
+        20: 'EXT:myextension/Resources/Private/Language/locallang.xlf'
+-----
+Form:
+  renderingOptions:
+    translation:
+      translationFiles:
+        20: 'EXT:myextension/Resources/Private/Language/locallang.xlf'

--- a/packages/fractor-yaml/tests/YamlProcessResult/Fixtures/rule-only.yaml.fixture
+++ b/packages/fractor-yaml/tests/YamlProcessResult/Fixtures/rule-only.yaml.fixture
@@ -1,0 +1,12 @@
+Form:
+  renderingOptions:
+    translation:
+      translationFile:
+        10: 'EXT:form/Resources/Private/Language/locallang.xlf'
+        20: 'EXT:myextension/Resources/Private/Language/locallang.xlf'
+-----
+Form:
+  renderingOptions:
+    translation:
+      translationFiles:
+        20: 'EXT:myextension/Resources/Private/Language/locallang.xlf'

--- a/packages/fractor-yaml/tests/YamlProcessResult/Fixtures/untouched-with-comment.yaml.fixture
+++ b/packages/fractor-yaml/tests/YamlProcessResult/Fixtures/untouched-with-comment.yaml.fixture
@@ -1,0 +1,4 @@
+# this comment survives because no rule rewrites the file
+Form:
+  renderingOptions:
+    skinning: true

--- a/packages/fractor-yaml/tests/YamlProcessResult/YamlProcessResultTest.php
+++ b/packages/fractor-yaml/tests/YamlProcessResult/YamlProcessResultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\FractorYaml\Tests\YamlProcessResult;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use a9f\FractorYaml\Tests\Fixtures\DummyYamlFractorRule;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The YAML dumper cannot preserve comments, so the processor only re-dumps files
+ * a rule already rewrites — never for formatting alone. On such a file the rule
+ * stays attributed to itself, and any reformatting that rides along (indentation,
+ * lost comments) is additionally attributed to the virtual CodeFormatRule. A file
+ * no rule touches is left byte-exact, even when it carries comments.
+ */
+final class YamlProcessResultTest extends AbstractFractorTestCase
+{
+    /**
+     * @param list<string> $expectedAppliedRules
+     */
+    #[DataProvider('provideData')]
+    public function test(string $fixture, array $expectedAppliedRules): void
+    {
+        $fractorTestResult = $this->doTestFile(__DIR__ . '/Fixtures/' . $fixture);
+
+        self::assertSame($expectedAppliedRules, $fractorTestResult->getAppliedFractorRules());
+    }
+
+    /**
+     * @return \Iterator<string, array{string, list<string>}>
+     */
+    public static function provideData(): \Iterator
+    {
+        yield 'rule change on canonical input is attributed to the real rule' => [
+            'rule-only.yaml.fixture',
+            [DummyYamlFractorRule::class],
+        ];
+        yield 'reformatting that rides along a rule is also attributed to the code-format rule' => [
+            'rule-and-reformat.yaml.fixture',
+            [AppliedRule::CODE_FORMAT_RULE, DummyYamlFractorRule::class],
+        ];
+        yield 'a file no rule touches is left byte-exact' => ['untouched-with-comment.yaml.fixture', []];
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+}

--- a/packages/fractor-yaml/tests/YamlProcessResult/config/fractor.php
+++ b/packages/fractor-yaml/tests/YamlProcessResult/config/fractor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\FractorYaml\Tests\Fixtures\DummyYamlFractorRule;
+
+return FractorConfiguration::configure()
+    ->withRules([DummyYamlFractorRule::class]);

--- a/packages/fractor/src/Application/FractorRunner.php
+++ b/packages/fractor/src/Application/FractorRunner.php
@@ -7,6 +7,7 @@ namespace a9f\Fractor\Application;
 use a9f\Fractor\Application\Contract\FileProcessor;
 use a9f\Fractor\Application\Contract\FileWriter;
 use a9f\Fractor\Application\Contract\FractorRule;
+use a9f\Fractor\Application\ValueObject\AppliedRule;
 use a9f\Fractor\Application\ValueObject\File;
 use a9f\Fractor\Caching\Detector\ChangedFilesDetector;
 use a9f\Fractor\Configuration\ConfigurationRuleFilter;
@@ -65,7 +66,8 @@ final readonly class FractorRunner
 
         $totalChanged = 0;
         foreach ($filePaths as $filePath) {
-            $file = new File($filePath, FileSystem::read($filePath));
+            $rawContent = FileSystem::read($filePath);
+            $file = new File($filePath, $rawContent);
             $this->fileCollector->addFile($file);
 
             if ($shouldShowProgressBar) {
@@ -91,6 +93,13 @@ final readonly class FractorRunner
             }
 
             ++$totalChanged;
+
+            // flag code formatting whenever the file was re-formatted: no real rule ran
+            // (pure reformat) or the normalized baseline differs from the raw input
+            // (reindent alongside a rule)
+            if ($file->getAppliedRules() === [] || $file->getOriginalContent() !== $rawContent) {
+                $file->addAppliedRule(AppliedRule::codeFormat());
+            }
 
             $file->setFileDiff($this->fileDiffFactory->createFileDiff($configuration->shouldShowDiffs(), $file));
 

--- a/packages/fractor/src/Application/ValueObject/AppliedRule.php
+++ b/packages/fractor/src/Application/ValueObject/AppliedRule.php
@@ -9,7 +9,12 @@ use a9f\Fractor\Application\Contract\FractorRule;
 final readonly class AppliedRule
 {
     /**
-     * @param class-string<FractorRule> $fractorClass
+     * Identifier for the virtual code-formatting rule, which has no backing class.
+     */
+    public const CODE_FORMAT_RULE = 'CodeFormatRule';
+
+    /**
+     * @param class-string<FractorRule>|self::CODE_FORMAT_RULE $fractorClass
      */
     private function __construct(
         private string $fractorClass,
@@ -29,11 +34,21 @@ final readonly class AppliedRule
         return new self($fractorRule);
     }
 
+    public static function codeFormat(): self
+    {
+        return new self(self::CODE_FORMAT_RULE);
+    }
+
     /**
-     * @return class-string<FractorRule>
+     * @return class-string<FractorRule>|self::CODE_FORMAT_RULE
      */
     public function getFractorClass(): string
     {
         return $this->fractorClass;
+    }
+
+    public function isCodeFormat(): bool
+    {
+        return $this->fractorClass === self::CODE_FORMAT_RULE;
     }
 }

--- a/packages/fractor/src/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/packages/fractor/src/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -71,7 +71,14 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
             $message = \sprintf('<options=bold>%d) %s</>', ++$i, $filePath);
             $this->symfonyStyle->writeln($message);
             $this->symfonyStyle->newLine();
-            $this->symfonyStyle->writeln($fileDiff->getDiffConsoleFormatted());
+
+            // reformatting/normalization only: show a one-liner instead of dumping the whole file
+            if ($fileDiff->isCodeFormatOnly()) {
+                $this->symfonyStyle->writeln('    <fg=yellow>~ reformatted / normalized</>');
+                $this->symfonyStyle->newLine();
+            } else {
+                $this->symfonyStyle->writeln($fileDiff->getDiffConsoleFormatted());
+            }
 
             if ($fileDiff->getAppliedRules() !== []) {
                 $this->symfonyStyle->writeln('<options=underscore>Applied rules:</>');
@@ -111,7 +118,7 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
         $this->symfonyStyle->section('Rules Summary');
 
         foreach ($ruleApplicationCounts as $ruleClass => $count) {
-            $ruleShortClass = (string) Strings::after($ruleClass, '\\', -1);
+            $ruleShortClass = Strings::after($ruleClass, '\\', -1) ?? $ruleClass;
             $this->symfonyStyle->writeln(sprintf(
                 ' * <info>%s</info> %s <comment>%d</comment> time%s',
                 $ruleShortClass,

--- a/packages/fractor/src/Differ/ValueObject/FileDiff.php
+++ b/packages/fractor/src/Differ/ValueObject/FileDiff.php
@@ -79,13 +79,14 @@ final readonly class FileDiff
     {
         $fractorShortClasses = [];
         foreach ($this->getFractorClasses() as $fractorClass) {
-            $fractorShortClasses[] = (string) Strings::after($fractorClass, '\\', -1);
+            // fall back to the full identifier for labels without a namespace (e.g. the code-format rule)
+            $fractorShortClasses[] = Strings::after($fractorClass, '\\', -1) ?? $fractorClass;
         }
         return $fractorShortClasses;
     }
 
     /**
-     * @return array<class-string<FractorRule>>
+     * @return array<class-string<FractorRule>|AppliedRule::CODE_FORMAT_RULE>
      */
     public function getFractorClasses(): array
     {
@@ -96,6 +97,19 @@ final readonly class FileDiff
         $fractorClasses = array_unique($fractorClasses);
         sort($fractorClasses);
         return $fractorClasses;
+    }
+
+    public function isCodeFormatOnly(): bool
+    {
+        if ($this->appliedRules === []) {
+            return false;
+        }
+        foreach ($this->appliedRules as $appliedRule) {
+            if (! $appliedRule->isCodeFormat()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public function getFirstLineNumber(): ?int

--- a/packages/fractor/src/Reporting/ChangelogExtractor.php
+++ b/packages/fractor/src/Reporting/ChangelogExtractor.php
@@ -5,16 +5,22 @@ declare(strict_types=1);
 namespace a9f\Fractor\Reporting;
 
 use a9f\Fractor\Application\Contract\FractorRule;
+use a9f\Fractor\Application\ValueObject\AppliedRule;
 use Nette\Utils\Strings;
 use Webmozart\Assert\Assert;
 
 final class ChangelogExtractor
 {
     /**
-     * @param class-string<FractorRule> $ruleClassName
+     * @param class-string<FractorRule>|AppliedRule::CODE_FORMAT_RULE $ruleClassName
      */
     public function extractChangelogFromRule(string $ruleClassName): ?string
     {
+        // the virtual code-formatting rule has no backing class to reflect on
+        if ($ruleClassName === AppliedRule::CODE_FORMAT_RULE) {
+            return null;
+        }
+
         Assert::isAOf($ruleClassName, FractorRule::class);
 
         $reflectionClass = new \ReflectionClass($ruleClassName);

--- a/packages/fractor/src/Reporting/FractorsChangelogLinesResolver.php
+++ b/packages/fractor/src/Reporting/FractorsChangelogLinesResolver.php
@@ -24,7 +24,7 @@ final readonly class FractorsChangelogLinesResolver
 
         $fractorsChangelogsLines = [];
         foreach ($rectorsChangelogs as $fractorClass => $changelog) {
-            $fractorShortClass = (string) Strings::after($fractorClass, '\\', -1);
+            $fractorShortClass = Strings::after($fractorClass, '\\', -1) ?? $fractorClass;
             $fractorsChangelogsLines[] = $changelog === null ? $fractorShortClass : $fractorShortClass . ' (' . $changelog . ')';
         }
 

--- a/packages/fractor/src/Reporting/FractorsChangelogResolver.php
+++ b/packages/fractor/src/Reporting/FractorsChangelogResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace a9f\Fractor\Reporting;
 
+use a9f\Fractor\Application\Contract\FractorRule;
 use a9f\Fractor\Application\ValueObject\AppliedRule;
 
 final readonly class FractorsChangelogResolver
@@ -15,7 +16,7 @@ final readonly class FractorsChangelogResolver
 
     /**
      * @param AppliedRule[] $appliedRules
-     * @return array<class-string, string|null>
+     * @return array<class-string<FractorRule>|AppliedRule::CODE_FORMAT_RULE, string|null>
      */
     public function resolveIncludingMissing(array $appliedRules): array
     {

--- a/packages/fractor/src/Testing/PHPUnit/AbstractFractorTestCase.php
+++ b/packages/fractor/src/Testing/PHPUnit/AbstractFractorTestCase.php
@@ -89,7 +89,7 @@ abstract class AbstractFractorTestCase extends TestCase implements FractorTestIn
         return FixtureFileFinder::yieldDirectory($directory, $suffix);
     }
 
-    protected function doTestFile(string $fixtureFilePath): void
+    protected function doTestFile(string $fixtureFilePath): FractorTestResult
     {
         // prepare input file contents and expected file output contents
         $fixtureFileContents = FileSystem::read($fixtureFilePath);
@@ -115,7 +115,7 @@ abstract class AbstractFractorTestCase extends TestCase implements FractorTestIn
         // write temp file
         FileSystem::write($inputFilePath, $inputFileContents, null);
 
-        $this->doTestFileMatchesExpectedContent($inputFilePath, $expectedFileContents, $fixtureFilePath);
+        return $this->doTestFileMatchesExpectedContent($inputFilePath, $expectedFileContents, $fixtureFilePath);
     }
 
     /**
@@ -144,7 +144,7 @@ abstract class AbstractFractorTestCase extends TestCase implements FractorTestIn
         string $originalFilePath,
         string $expectedFileContents,
         string $fixtureFilePath
-    ): void {
+    ): FractorTestResult {
         // the file is now changed (if any rule matches)
         $fractorTestResult = $this->processFilePath($originalFilePath);
         $changedContents = $fractorTestResult->getChangedContents();
@@ -161,6 +161,8 @@ abstract class AbstractFractorTestCase extends TestCase implements FractorTestIn
         }
 
         self::assertSame(trim($expectedFileContents), trim($changedContents), $failureMessage);
+
+        return $fractorTestResult;
     }
 
     /**

--- a/packages/fractor/src/Testing/PHPUnit/ValueObject/FractorTestResult.php
+++ b/packages/fractor/src/Testing/PHPUnit/ValueObject/FractorTestResult.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace a9f\Fractor\Testing\PHPUnit\ValueObject;
 
 use a9f\Fractor\Application\Contract\FractorRule;
+use a9f\Fractor\Application\ValueObject\AppliedRule;
 use a9f\Fractor\ValueObject\ProcessResult;
 
 final readonly class FractorTestResult
@@ -21,7 +22,7 @@ final readonly class FractorTestResult
     }
 
     /**
-     * @return array<class-string<FractorRule>>
+     * @return array<class-string<FractorRule>|AppliedRule::CODE_FORMAT_RULE>
      */
     public function getAppliedFractorRules(): array
     {

--- a/packages/fractor/src/ValueObject/ProcessResult.php
+++ b/packages/fractor/src/ValueObject/ProcessResult.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace a9f\Fractor\ValueObject;
 
 use a9f\Fractor\Application\Contract\FractorRule;
+use a9f\Fractor\Application\ValueObject\AppliedRule;
 use a9f\Fractor\Differ\ValueObject\FileDiff;
 use Webmozart\Assert\Assert;
 
@@ -26,7 +27,10 @@ final readonly class ProcessResult
     public function getFileDiffs(bool $onlyWithChanges = true): array
     {
         if ($onlyWithChanges) {
-            return array_filter($this->fileDiffs, static fn (FileDiff $fileDiff): bool => $fileDiff->getDiff() !== '');
+            return array_filter(
+                $this->fileDiffs,
+                static fn (FileDiff $fileDiff): bool => $fileDiff->getDiff() !== '' || $fileDiff->getAppliedRules() !== []
+            );
         }
         return $this->fileDiffs;
     }
@@ -37,7 +41,7 @@ final readonly class ProcessResult
     }
 
     /**
-     * @return array<class-string<FractorRule>, int>
+     * @return array<class-string<FractorRule>|AppliedRule::CODE_FORMAT_RULE, int>
      */
     public function getRuleApplicationCounts(): array
     {

--- a/packages/fractor/tests/Application/CodeFormatRule/CodeFormatRuleTest.php
+++ b/packages/fractor/tests/Application/CodeFormatRule/CodeFormatRuleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\Fractor\Tests\Application\CodeFormatRule;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Testing\PHPUnit\AbstractFractorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The virtual CodeFormatRule lives in the runner, not in any single processor:
+ * whenever a processor re-formats a file without attributing a real rule, the
+ * change must be recognised as code formatting. This exercises that path through
+ * a plain text processor to prove it is processor-agnostic.
+ */
+final class CodeFormatRuleTest extends AbstractFractorTestCase
+{
+    /**
+     * @param list<string> $expectedAppliedRules
+     */
+    #[DataProvider('provideData')]
+    public function test(string $fixture, array $expectedAppliedRules): void
+    {
+        $fractorTestResult = $this->doTestFile(__DIR__ . '/Fixtures/' . $fixture);
+
+        self::assertSame($expectedAppliedRules, $fractorTestResult->getAppliedFractorRules());
+    }
+
+    /**
+     * @return \Iterator<string, array{string, list<string>}>
+     */
+    public static function provideData(): \Iterator
+    {
+        // Trailing whitespace gets trimmed by a rule that records nothing: the
+        // runner must recognise the change as code formatting on its own.
+        yield 'reformat without a real rule is attributed to the code-format rule' => [
+            'trailing-whitespace.txt.fixture',
+            [AppliedRule::CODE_FORMAT_RULE],
+        ];
+        // Nothing to trim: no change is reported and no rule is applied.
+        yield 'already clean file reports no change' => ['clean.txt.fixture', []];
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/fractor.php';
+    }
+
+    protected function additionalConfigurationFiles(): array
+    {
+        return [__DIR__ . '/../FractorRunner/config/config.php'];
+    }
+}

--- a/packages/fractor/tests/Application/CodeFormatRule/Fixtures/clean.txt.fixture
+++ b/packages/fractor/tests/Application/CodeFormatRule/Fixtures/clean.txt.fixture
@@ -1,0 +1,2 @@
+first line
+second line

--- a/packages/fractor/tests/Application/CodeFormatRule/Fixtures/trailing-whitespace.txt.fixture
+++ b/packages/fractor/tests/Application/CodeFormatRule/Fixtures/trailing-whitespace.txt.fixture
@@ -1,0 +1,7 @@
+first line   
+second line	
+third line
+-----
+first line
+second line
+third line

--- a/packages/fractor/tests/Application/CodeFormatRule/config/fractor.php
+++ b/packages/fractor/tests/Application/CodeFormatRule/config/fractor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\Fractor\Tests\Fixture\DummyProcessor\Rules\NormalizeWhitespaceTextRule;
+
+return FractorConfiguration::configure()
+    ->withRules([NormalizeWhitespaceTextRule::class]);

--- a/packages/fractor/tests/Application/ValueObject/AppliedRule/AppliedRuleTest.php
+++ b/packages/fractor/tests/Application/ValueObject/AppliedRule/AppliedRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\Fractor\Tests\Application\ValueObject\AppliedRule;
+
+use a9f\Fractor\Application\ValueObject\AppliedRule;
+use a9f\Fractor\Tests\Reporting\ChangelogExtractor\Fixture\RuleWithNoChangelog;
+use PHPUnit\Framework\TestCase;
+
+final class AppliedRuleTest extends TestCase
+{
+    public function testCodeFormatFactoryProducesTheVirtualRule(): void
+    {
+        $appliedRule = AppliedRule::codeFormat();
+
+        self::assertSame(AppliedRule::CODE_FORMAT_RULE, $appliedRule->getFractorClass());
+        self::assertTrue($appliedRule->isCodeFormat());
+    }
+
+    public function testRealRuleIsNotCodeFormat(): void
+    {
+        $appliedRule = AppliedRule::fromClassString(RuleWithNoChangelog::class);
+
+        self::assertFalse($appliedRule->isCodeFormat());
+    }
+}

--- a/packages/fractor/tests/Fixture/DummyProcessor/Rules/NormalizeWhitespaceTextRule.php
+++ b/packages/fractor/tests/Fixture/DummyProcessor/Rules/NormalizeWhitespaceTextRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace a9f\Fractor\Tests\Fixture\DummyProcessor\Rules;
+
+use a9f\Fractor\Application\ValueObject\File;
+use a9f\Fractor\Tests\Fixture\DummyProcessor\Contract\TextRule;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Trims trailing whitespace from every line: a purely cosmetic reformat that
+ * changes the file without attributing a semantic rule, so the runner has to
+ * recognise it as a code-format change.
+ *
+ * @changelog https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog-11.html
+ */
+final class NormalizeWhitespaceTextRule implements TextRule
+{
+    public function apply(File $file): void
+    {
+        $lines = explode("\n", $file->getContent());
+        $trimmedLines = array_map(rtrim(...), $lines);
+
+        $file->changeFileContent(implode("\n", $trimmedLines));
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Trim trailing whitespace from every line', [new CodeSample("a \nb ", "a\nb")]);
+    }
+}

--- a/packages/fractor/tests/Reporting/ChangelogExtractor/ChangelogExtractorTest.php
+++ b/packages/fractor/tests/Reporting/ChangelogExtractor/ChangelogExtractorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace a9f\Fractor\Tests\Reporting\ChangelogExtractor;
 
+use a9f\Fractor\Application\ValueObject\AppliedRule;
 use a9f\Fractor\Reporting\ChangelogExtractor;
 use a9f\Fractor\Tests\Reporting\ChangelogExtractor\Fixture\RuleWithChangelog;
 use a9f\Fractor\Tests\Reporting\ChangelogExtractor\Fixture\RuleWithNoChangelog;
@@ -24,6 +25,13 @@ final class ChangelogExtractorTest extends TestCase
     {
         // Act & Assert
         self::assertNull($this->subject->extractChangelogFromRule(RuleWithNoChangelog::class));
+    }
+
+    #[Test]
+    public function virtualCodeFormatRuleIsToleratedWithoutReflection(): void
+    {
+        // the code-format label has no backing class; it must not be reflected on
+        self::assertNull($this->subject->extractChangelogFromRule(AppliedRule::CODE_FORMAT_RULE));
     }
 
     #[Test]


### PR DESCRIPTION
This PR adds a virtual `CodeFormatRule` so that formatting-only changes (a pure reformat, or reindentation riding along with a real rule) finally get counted, surfaced in the report, and factored into the dry-run exit code — instead of Fractor silently rewriting files with nobody the wiser. And by the way, it also fixes #427.

`CodeFormatRule` isn't a registrable rule, just a marker `AppliedRule` knows about (`codeFormat()` / `isCodeFormat()`). `FractorRunner` attaches it when no real rule ran or the normalized baseline differs from the raw input. In the console, a formatting-only file skips the diff dump and shows a `~ reformatted / normalized` one-liner plus `CodeFormatRule` under "Applied rules"; real rule changes render as before.

Also includes a small YAML fix (re-dump the original as baseline so the diff shows only the rule's change; skip re-dumping for formatting alone, since the dumper drops comments) and `ProcessResult` coverage for every reformatting format — composer.json, TypoScript, XML, XLIFF, YAML — plus core `CodeFormatRule`/`AppliedRule` tests.